### PR TITLE
Attempt to fix carriage return issues

### DIFF
--- a/src/pytokens/__init__.py
+++ b/src/pytokens/__init__.py
@@ -318,7 +318,7 @@ class TokenIterator:
         )
 
     def newline(self) -> Token:
-        if self.is_in_bounds() and self.source[self.current_index] == "\r":
+        if self.is_newline() == 2:
             self.advance()
         self.advance()
         token_type = (
@@ -755,23 +755,27 @@ class TokenIterator:
         char = self.source[self.current_index]
         return (
             char == " "
-            or char == "\r"
+            or (char == "\r" and not self.issue_128233_handling)
             or char == "\t"
             or char == "\x0b"
             or char == "\x0c"
         )
 
-    def is_newline(self) -> bool:
+    def is_newline(self) -> int:
+        if not self.is_in_bounds():
+            return 0
         if self.source[self.current_index] == "\n":
-            return True
+            return 1
         if (
             self.source[self.current_index] == "\r"
             and self.current_index + 1 < len(self.source)
             and self.source[self.current_index + 1] == "\n"
         ):
-            return True
+            return 2
+        if self.issue_128233_handling and self.source[self.current_index] == "\r":
+            return 1
 
-        return False
+        return 0
 
     def name(self) -> Token:
         if self.weird_op_case:
@@ -879,9 +883,8 @@ class TokenIterator:
                 if self.is_whitespace():
                     self.advance()
                     found_whitespace = True
-                elif not seen_newline and (self.is_newline()):
-                    char = self.source[self.current_index]
-                    if char == "\r":
+                elif not seen_newline and (advance_count := self.is_newline()):
+                    if advance_count == 2:
                         self.advance()
                     self.advance()
                     found_whitespace = True


### PR DESCRIPTION
This is my attempt at fixing the carriage return problems. In combination with https://github.com/psf/black/pull/4674  , this should fix the hypothesis errors around `\r`.

I'm making both PRs drafts since my changes were made with the consideration of a sledgehammer, and were just focused on getting the issue to go away, so I'm uncertain if I've accidentally broken other things. All the black tests pass, as well as a local hypothesis run gave no problems, but I might have messed something up.

<details open>
<summary> pytokens changes </summary>

My general change is based around the fact that I don't understand how you could fix `issue_128233` without making `\r`s behave properly as newlines, so that's what this PR does. If `issue_128233_handling` is enabled, `\r`s are treated as newlines instead of whitespace.

With this change, I came across issues where a lone `\r` newline would cause a double advance to happen, so I made `is_newline` return an `int` with the length of chars that should be removed. This keeps the old behavior intact, since 0 is still falsey and 1/2 are truthy, but also allows the methods that depend on `\r\n` handling to work correctly through checking if the result is 2.

</details>

<details>
<summary> black changes </summary>

While working on the other hypothesis issues, I noticed that `\r`s weren't accounted for properly in the driver, so this adds those checks, leaving the `\n` ones first to hopefully leave `\r\n` behavior unchanged.

</details>

I also have no clue how to handle the cross-repository things that would make the tests show as passing, since they don't have the full effects without the other repo's changes.

One other note, I wonder if it would be easier to side-step all these problems completely and normalize the newlines early like how CPython does, probably in `src/black/__init__.py:format_str`