### PR TITLE
Don't include tests/__pycache__ in sdists

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,1 @@
-recursive-include tests *
+recursive-include tests *.py


### PR DESCRIPTION
`tests/*.py` is useful, but the 0.2.0 sdist also contains a Python 3.12 `.pyc` file from the maintainer's system.  It probably shouldn't.